### PR TITLE
Specify system, time/date, string, and numeric functions lists

### DIFF
--- a/src/main/java/com/taosdata/jdbc/AbstractDatabaseMetaData.java
+++ b/src/main/java/com/taosdata/jdbc/AbstractDatabaseMetaData.java
@@ -169,19 +169,19 @@ public abstract class AbstractDatabaseMetaData extends WrapperImpl implements Da
     }
 
     public String getNumericFunctions() throws SQLException {
-        return null;
+        return "ABS,ACOS,ASIN,ATAN,CEIL,COS,FLOOR,LOG,POW,ROUND,SIN,SQRT,TAN";
     }
 
     public String getStringFunctions() throws SQLException {
-        return null;
+        return "CHAR_LENGTH,CONCAT,CONCAT_WS,LENGTH,LOWER,LTRIM,RTRIM,SUBSTR,UPPER";
     }
 
     public String getSystemFunctions() throws SQLException {
-        return null;
+        return "DATABASE,CLIENT_VERSION,SERVER_VERSION,SERVER_STATUS,CURRENT_USER";
     }
 
     public String getTimeDateFunctions() throws SQLException {
-        return null;
+        return "NOW,TIMEDIFF,TIMETRUNCATE,TIMEZONE,TODAY";
     }
 
     public String getSearchStringEscape() throws SQLException {

--- a/src/test/java/com/taosdata/jdbc/TSDBDatabaseMetaDataTest.java
+++ b/src/test/java/com/taosdata/jdbc/TSDBDatabaseMetaDataTest.java
@@ -160,22 +160,22 @@ public class TSDBDatabaseMetaDataTest {
 
     @Test
     public void getNumericFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getNumericFunctions());
+        Assert.assertEquals("ABS,ACOS,ASIN,ATAN,CEIL,COS,FLOOR,LOG,POW,ROUND,SIN,SQRT,TAN", metaData.getNumericFunctions());
     }
 
     @Test
     public void getStringFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getStringFunctions());
+        Assert.assertEquals("CHAR_LENGTH,CONCAT,CONCAT_WS,LENGTH,LOWER,LTRIM,RTRIM,SUBSTR,UPPER", metaData.getStringFunctions());
     }
 
     @Test
     public void getSystemFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getSystemFunctions());
+        Assert.assertEquals("DATABASE,CLIENT_VERSION,SERVER_VERSION,SERVER_STATUS,CURRENT_USER", metaData.getSystemFunctions());
     }
 
     @Test
     public void getTimeDateFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getTimeDateFunctions());
+        Assert.assertEquals("NOW,TIMEDIFF,TIMETRUNCATE,TIMEZONE,TODAY", metaData.getTimeDateFunctions());
     }
 
     @Test

--- a/src/test/java/com/taosdata/jdbc/rs/RestfulDatabaseMetaDataTest.java
+++ b/src/test/java/com/taosdata/jdbc/rs/RestfulDatabaseMetaDataTest.java
@@ -162,22 +162,22 @@ public class RestfulDatabaseMetaDataTest {
 
     @Test
     public void getNumericFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getNumericFunctions());
+        Assert.assertEquals("ABS,ACOS,ASIN,ATAN,CEIL,COS,FLOOR,LOG,POW,ROUND,SIN,SQRT,TAN", metaData.getNumericFunctions());
     }
 
     @Test
     public void getStringFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getStringFunctions());
+        Assert.assertEquals("CHAR_LENGTH,CONCAT,CONCAT_WS,LENGTH,LOWER,LTRIM,RTRIM,SUBSTR,UPPER", metaData.getStringFunctions());
     }
 
     @Test
     public void getSystemFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getSystemFunctions());
+        Assert.assertEquals("DATABASE,CLIENT_VERSION,SERVER_VERSION,SERVER_STATUS,CURRENT_USER", metaData.getSystemFunctions());
     }
 
     @Test
     public void getTimeDateFunctions() throws SQLException {
-        Assert.assertEquals(null, metaData.getTimeDateFunctions());
+        Assert.assertEquals("NOW,TIMEDIFF,TIMETRUNCATE,TIMEZONE,TODAY", metaData.getTimeDateFunctions());
     }
 
     @Test


### PR DESCRIPTION
Hello.

I've added some functions to the driver.

Used values from this documentation: https://docs.tdengine.com/taos-sql/function/

I was not sure about the keywords list (https://docs.tdengine.com/taos-sql/keywords/), and this comment from the method (`String getSQLKeywords()`) documentation:
`Retrieves a comma-separated list of all of this database's SQL keywords that are NOT also SQL:2003 keywords`

So, didn't add keywords as well. 