### PR TITLE
fix: unsigned tinyint/smallint/int/bigint exceed range issue

### DIFF
--- a/src/main/java/com/taosdata/jdbc/TSDBResultSetMetaData.java
+++ b/src/main/java/com/taosdata/jdbc/TSDBResultSetMetaData.java
@@ -179,37 +179,7 @@ public class TSDBResultSetMetaData extends WrapperImpl implements ResultSetMetaD
     }
 
     public String getColumnClassName(int column) throws SQLException {
-        int columnType = getColumnType(column);
-        String columnClassName = "";
-        switch (columnType) {
-            case Types.TIMESTAMP:
-                columnClassName = Timestamp.class.getName();
-                break;
-            case Types.CHAR:
-                columnClassName = String.class.getName();
-                break;
-            case Types.DOUBLE:
-                columnClassName = Double.class.getName();
-                break;
-            case Types.FLOAT:
-                columnClassName = Float.class.getName();
-                break;
-            case Types.BIGINT:
-                columnClassName = Long.class.getName();
-                break;
-            case Types.INTEGER:
-                columnClassName = Integer.class.getName();
-                break;
-            case Types.SMALLINT:
-                columnClassName = Short.class.getName();
-                break;
-            case Types.TINYINT:
-                columnClassName = Byte.class.getName();
-                break;
-            case Types.BIT:
-                columnClassName = Boolean.class.getName();
-                break;
-        }
-        return columnClassName;
+        ColumnMetaData meta = this.colMetaDataList.get(column - 1);
+        return DataType.convertTaosType2DataType(meta.getColType()).getClassName();
     }
 }

--- a/src/main/java/com/taosdata/jdbc/enums/DataType.java
+++ b/src/main/java/com/taosdata/jdbc/enums/DataType.java
@@ -4,43 +4,47 @@ import com.taosdata.jdbc.TSDBError;
 import com.taosdata.jdbc.TSDBErrorNumbers;
 import com.taosdata.jdbc.utils.StringUtils;
 
+import java.math.BigInteger;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 
 import static com.taosdata.jdbc.TSDBConstants.*;
 
 public enum DataType {
-    NULL("NULL", Types.NULL, TSDB_DATA_TYPE_NULL, 0),
-    BOOL("BOOL", Types.BOOLEAN, TSDB_DATA_TYPE_BOOL, BOOLEAN_PRECISION),
-    TINYINT("TINYINT", Types.TINYINT, TSDB_DATA_TYPE_TINYINT, TINYINT_PRECISION),
-    UTINYINT("TINYINT UNSIGNED", Types.TINYINT, TSDB_DATA_TYPE_UTINYINT, TINYINT_PRECISION),
-    USMALLINT("SMALLINT UNSIGNED", Types.SMALLINT, TSDB_DATA_TYPE_USMALLINT, SMALLINT_PRECISION),
-    SMALLINT("SMALLINT", Types.SMALLINT, TSDB_DATA_TYPE_SMALLINT, SMALLINT_PRECISION),
-    UINT("INT UNSIGNED", Types.INTEGER, TSDB_DATA_TYPE_UINT, INT_PRECISION),
-    INT("INT", Types.INTEGER, TSDB_DATA_TYPE_INT, INT_PRECISION),
-    UBIGINT("BIGINT UNSIGNED", Types.BIGINT, TSDB_DATA_TYPE_UBIGINT, BIGINT_PRECISION),
-    BIGINT("BIGINT", Types.BIGINT, TSDB_DATA_TYPE_BIGINT, BIGINT_PRECISION),
-    FLOAT("FLOAT", Types.FLOAT, TSDB_DATA_TYPE_FLOAT, FLOAT_PRECISION),
-    DOUBLE("DOUBLE", Types.DOUBLE, TSDB_DATA_TYPE_DOUBLE, DOUBLE_PRECISION),
-    BINARY("BINARY", Types.VARCHAR, TSDB_DATA_TYPE_BINARY, 0),
-    VARCHAR("VARCHAR", Types.VARCHAR, TSDB_DATA_TYPE_VARCHAR, 0),
-    TIMESTAMP("TIMESTAMP", Types.TIMESTAMP, TSDB_DATA_TYPE_TIMESTAMP, 0),
-    NCHAR("NCHAR", Types.NCHAR, TSDB_DATA_TYPE_NCHAR, 0),
-    JSON("JSON", Types.OTHER, TSDB_DATA_TYPE_JSON, 0),
-    VARBINARY("VARBINARY", Types.VARBINARY, TSDB_DATA_TYPE_VARBINARY, 0),
-    GEOMETRY("GEOMETRY", Types.BINARY, TSDB_DATA_TYPE_GEOMETRY, 0),
+    NULL("NULL", Types.NULL, Object.class, TSDB_DATA_TYPE_NULL, 0),
+    BOOL("BOOL", Types.BOOLEAN, Boolean.class, TSDB_DATA_TYPE_BOOL, BOOLEAN_PRECISION),
+    TINYINT("TINYINT", Types.TINYINT, Byte.class, TSDB_DATA_TYPE_TINYINT, TINYINT_PRECISION),
+    UTINYINT("TINYINT UNSIGNED", Types.TINYINT, Short.class, TSDB_DATA_TYPE_UTINYINT, TINYINT_PRECISION),
+    USMALLINT("SMALLINT UNSIGNED", Types.SMALLINT, Integer.class, TSDB_DATA_TYPE_USMALLINT, SMALLINT_PRECISION),
+    SMALLINT("SMALLINT", Types.SMALLINT, Short.class, TSDB_DATA_TYPE_SMALLINT, SMALLINT_PRECISION),
+    UINT("INT UNSIGNED", Types.INTEGER, Long.class, TSDB_DATA_TYPE_UINT, INT_PRECISION),
+    INT("INT", Types.INTEGER, Integer.class, TSDB_DATA_TYPE_INT, INT_PRECISION),
+    UBIGINT("BIGINT UNSIGNED", Types.BIGINT, BigInteger.class, TSDB_DATA_TYPE_UBIGINT, BIGINT_PRECISION),
+    BIGINT("BIGINT", Types.BIGINT, Long.class, TSDB_DATA_TYPE_BIGINT, BIGINT_PRECISION),
+    FLOAT("FLOAT", Types.FLOAT, Float.class, TSDB_DATA_TYPE_FLOAT, FLOAT_PRECISION),
+    DOUBLE("DOUBLE", Types.DOUBLE, Double.class, TSDB_DATA_TYPE_DOUBLE, DOUBLE_PRECISION),
+    BINARY("BINARY", Types.VARCHAR, String.class, TSDB_DATA_TYPE_BINARY, 0),
+    VARCHAR("VARCHAR", Types.VARCHAR, String.class, TSDB_DATA_TYPE_VARCHAR, 0),
+    TIMESTAMP("TIMESTAMP", Types.TIMESTAMP, Timestamp.class, TSDB_DATA_TYPE_TIMESTAMP, 0),
+    NCHAR("NCHAR", Types.NCHAR, String.class, TSDB_DATA_TYPE_NCHAR, 0),
+    JSON("JSON", Types.OTHER, String.class, TSDB_DATA_TYPE_JSON, 0),
+    VARBINARY("VARBINARY", Types.VARBINARY, null, TSDB_DATA_TYPE_VARBINARY, 0),
+    GEOMETRY("GEOMETRY", Types.BINARY, null, TSDB_DATA_TYPE_GEOMETRY, 0),
     ;
 
     private final String typeName;
     private final int jdbcTypeValue;
+    private final Class<?> javaClass;
     private final int taosTypeValue;
     private final int size;
 
-    DataType(String typeName, int jdbcTypeValue, int taosTypeValue, int size) {
+    DataType(String typeName, int jdbcTypeValue, Class<?> javaClass, int taosTypeValue, int size) {
         this.typeName = typeName;
         this.jdbcTypeValue = jdbcTypeValue;
         this.taosTypeValue = taosTypeValue;
         this.size = size;
+        this.javaClass = javaClass;
     }
 
     public String getTypeName() {
@@ -53,6 +57,13 @@ public enum DataType {
 
     public int getJdbcTypeValue() {
         return jdbcTypeValue;
+    }
+
+    public String getClassName() {
+        if (this.javaClass == null) {
+            return "[B";
+        }
+        return this.javaClass.getName();
     }
 
     public int getSize() {

--- a/src/main/java/com/taosdata/jdbc/rs/RestfulResultSet.java
+++ b/src/main/java/com/taosdata/jdbc/rs/RestfulResultSet.java
@@ -254,8 +254,6 @@ public class RestfulResultSet extends AbstractResultSet {
         if (value == null)
             return 0;
         long valueAsLong = Long.parseLong(value.toString());
-        if (valueAsLong == Byte.MIN_VALUE)
-            return 0;
         if (valueAsLong < Byte.MIN_VALUE || valueAsLong > Byte.MAX_VALUE)
             throwRangeException(value.toString(), columnIndex, Types.TINYINT);
 
@@ -276,8 +274,6 @@ public class RestfulResultSet extends AbstractResultSet {
         if (value == null)
             return 0;
         long valueAsLong = Long.parseLong(value.toString());
-        if (valueAsLong == Short.MIN_VALUE)
-            return 0;
         if (valueAsLong < Short.MIN_VALUE || valueAsLong > Short.MAX_VALUE)
             throwRangeException(value.toString(), columnIndex, Types.SMALLINT);
         return (short) valueAsLong;
@@ -292,8 +288,6 @@ public class RestfulResultSet extends AbstractResultSet {
         if (value == null)
             return 0;
         long valueAsLong = Long.parseLong(value.toString());
-        if (valueAsLong == Integer.MIN_VALUE)
-            return 0;
         if (valueAsLong < Integer.MIN_VALUE || valueAsLong > Integer.MAX_VALUE)
             throwRangeException(value.toString(), columnIndex, Types.INTEGER);
         return (int) valueAsLong;
@@ -322,8 +316,6 @@ public class RestfulResultSet extends AbstractResultSet {
         long valueAsLong = 0;
         try {
             valueAsLong = Long.parseLong(value.toString());
-            if (valueAsLong == Long.MIN_VALUE)
-                return 0;
         } catch (NumberFormatException e) {
             throwRangeException(value.toString(), columnIndex, Types.BIGINT);
         }

--- a/src/main/java/com/taosdata/jdbc/rs/RestfulResultSetMetaData.java
+++ b/src/main/java/com/taosdata/jdbc/rs/RestfulResultSetMetaData.java
@@ -166,30 +166,7 @@ public class RestfulResultSetMetaData extends WrapperImpl implements ResultSetMe
 
     @Override
     public String getColumnClassName(int column) throws SQLException {
-        int type = this.fields.get(column - 1).type;
-        String columnClassName = "";
-        switch (type) {
-            case Types.BOOLEAN:
-                return Boolean.class.getName();
-            case Types.TINYINT:
-            case Types.SMALLINT:
-                return Short.class.getName();
-            case Types.INTEGER:
-                return Integer.class.getName();
-            case Types.BIGINT:
-                return Long.class.getName();
-            case Types.FLOAT:
-                return Float.class.getName();
-            case Types.DOUBLE:
-                return Double.class.getName();
-            case Types.TIMESTAMP:
-                return Timestamp.class.getName();
-            case Types.BINARY:
-            case Types.NCHAR:
-            case Types.VARCHAR:
-                return String.class.getName();
-        }
-        return columnClassName;
+        int taosType = fields.get(column - 1).taos_type;
+        return DataType.convertTaosType2DataType(taosType).getClassName();
     }
-
 }

--- a/src/test/java/com/taosdata/jdbc/rs/RestfulResultSetMetaDataTest.java
+++ b/src/test/java/com/taosdata/jdbc/rs/RestfulResultSetMetaDataTest.java
@@ -172,7 +172,7 @@ public class RestfulResultSetMetaDataTest {
         Assert.assertEquals(Double.class.getName(), meta.getColumnClassName(5));
         Assert.assertEquals(String.class.getName(), meta.getColumnClassName(6));
         Assert.assertEquals(Short.class.getName(), meta.getColumnClassName(7));
-        Assert.assertEquals(Short.class.getName(), meta.getColumnClassName(8));
+        Assert.assertEquals(Byte.class.getName(), meta.getColumnClassName(8));
         Assert.assertEquals(Boolean.class.getName(), meta.getColumnClassName(9));
         Assert.assertEquals(String.class.getName(), meta.getColumnClassName(10));
     }


### PR DESCRIPTION
Refer to [mysql-connector-j](https://github.com/mysql/mysql-connector-j/blob/release/8.x/src/main/core-api/java/com/mysql/cj/MysqlType.java#L81), map the following data types to corresponding java types:

* `UTINYINT` use Short instead of Byte.
* `USMALLINT` use Integer instead of Short.
* `UINT` use Long instead of Integer.
* `UBIGINT` use BigInteger instead of Long

Fix #150 