### PR TITLE
RestfulDriver column name ignore case

### DIFF
--- a/src/main/java/com/taosdata/jdbc/rs/RestfulResultSet.java
+++ b/src/main/java/com/taosdata/jdbc/rs/RestfulResultSet.java
@@ -14,7 +14,6 @@ import com.taosdata.jdbc.enums.DataType;
 import com.taosdata.jdbc.enums.TimestampPrecision;
 import com.taosdata.jdbc.utils.DateTimeUtils;
 import com.taosdata.jdbc.utils.JsonUtil;
-import com.taosdata.jdbc.utils.Utils;
 
 import java.math.BigDecimal;
 import java.sql.*;
@@ -105,7 +104,7 @@ public class RestfulResultSet extends AbstractResultSet {
         columns.clear();
         for (int colIndex = 0; colIndex < columnMeta.size(); colIndex++) {
             JsonNode col = columnMeta.get(colIndex);
-            String col_name = col.get(0).asText();
+            String col_name = col.get(0).asText().toLowerCase();
             String typeName = col.get(1).asText();
             DataType type = DataType.getDataType(typeName);
             int col_type = type.getJdbcTypeValue();
@@ -483,7 +482,7 @@ public class RestfulResultSet extends AbstractResultSet {
         if (isClosed())
             throw TSDBError.createSQLException(TSDBErrorNumbers.ERROR_RESULTSET_CLOSED);
 
-        int columnIndex = columnNames.indexOf(columnLabel);
+        int columnIndex = columnNames.indexOf(columnLabel == null ? null : columnLabel.toLowerCase());
         if (columnIndex == -1)
             throw new SQLException("cannot find Column in resultSet");
         return columnIndex + 1;


### PR DESCRIPTION
因数据库列名不区分大小写，使用大写的列名寻找数据会导致找不到列
问题复现步骤：

1. 创建表
```sql
create table column_name_test (ts timestamp,col NCHAR (64)) tags (t NCHAR (64))
```
2. 写入数据
```sql
insert into data_1 using column_name_test tags ('test tag') values ('2025-01-13 00:00:00','test data');
select * from column_name_test;
```
```
           ts            |              col               |               t                |
============================================================================================
 2025-01-13 00:00:00.000 | test data                      | test tag                       |
Query OK, 1 row(s) in set (0.001425s)
```
3.配置RestfulDriver
```
... 省略
<property name="jdbcUrl" value="jdbc:TAOS-RS://tdengine:6041/unittest"/>
<property name="driverClassName" value="com.taosdata.jdbc.rs.RestfulDriver"/>
... 省略
```
3.执行
```java
...
try (Connection connection = hikariDataSource.getConnection()){
              ResultSet resultSet = connection.prepareStatement("select * from column_name_test").executeQuery();
              if (resultSet.next()){
                  System.out.println("get col value:" + resultSet.getObject("col"));
                  System.out.println("get COL value:" +resultSet.getObject("COL"));
              }
 }
...
```
结果
```
get col value:test data
java.lang.RuntimeException: java.sql.SQLException: cannot find Column in resultSet

	at ...省略
Caused by: java.sql.SQLException: cannot find Column in resultSet
	at com.taosdata.jdbc.rs.RestfulResultSet.findColumn(RestfulResultSet.java:488)
	at com.taosdata.jdbc.AbstractResultSet.getObject(AbstractResultSet.java:236)
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
	at ..省略
	... 28 more
```