### PR TITLE
Fix nchar ClassCastException

### DIFF
--- a/src/main/java/com/taosdata/jdbc/common/SerializeBlock.java
+++ b/src/main/java/com/taosdata/jdbc/common/SerializeBlock.java
@@ -119,8 +119,7 @@ public class SerializeBlock {
                         break;
                     }
                     case TSDB_DATA_TYPE_NCHAR: {
-                        String v = (String) o;
-                        int len = v.getBytes().length;
+                        int len = ((byte[])o).length;
                         buf.writeIntLE(len);
                         bufferLength += len;
                         break;
@@ -346,9 +345,7 @@ public class SerializeBlock {
             case TSDB_DATA_TYPE_NCHAR: {
                 for (Object o: objectList){
                     if (o != null) {
-                        String v = (String) o;
-                        byte[] bytes = v.getBytes();
-                        serializeByteArray(buf, bytes);
+                        serializeByteArray(buf, (byte[])o);
                     }
                 }
                 break;
@@ -419,8 +416,7 @@ public class SerializeBlock {
                 int totalLength = 0;
                 for (Object o : column.getDataList()) {
                     if (o != null) {
-                        String v = (String) o;
-                        totalLength += v.getBytes().length;
+                        totalLength += ((byte[])o).length;
                     }
                 }
                 // TotalLength(4) + Type (4) + Num(4) + IsNull(1) * size + haveLength(1) + BufferLength(4) + 4 * v.length + totalLength


### PR DESCRIPTION
# Description

修复 assync_write 方式写入 nchar 字段时，类型转换错误问题。[issue-262](https://github.com/taosdata/taos-connector-jdbc/issues/262) 。 

问题在与 nchar 采用 `byte[]` 存储，不应该强制类型转换为 `String` .  


# Checklist
Please check the items in the checklist if applicable.
- [x] Is the user manual updated? No need
- [x] Are the test cases passed and automated?  
- [x] Is there no significant decrease in test coverage?


