### PR TITLE
feat: stop using regex pattern to escape single quota

### DIFF
--- a/src/main/java/com/taosdata/jdbc/utils/Utils.java
+++ b/src/main/java/com/taosdata/jdbc/utils/Utils.java
@@ -28,7 +28,6 @@ import java.util.stream.IntStream;
 public class Utils {
     private static final Logger log = LoggerFactory.getLogger(Utils.class);
     private static final ForkJoinPool forkJoinPool = new ForkJoinPool();
-    private static final Pattern ptn = Pattern.compile(".*?'");
 
     private static EventLoopGroup eventLoopGroup = null;
 

--- a/src/test/java/com/taosdata/jdbc/utils/UtilsTest.java
+++ b/src/test/java/com/taosdata/jdbc/utils/UtilsTest.java
@@ -74,6 +74,13 @@ public class UtilsTest {
         news = Utils.escapeSingleQuota(s);
         // then
         Assert.assertEquals("\\'\\'\\'a\\\\'\\'\\\\'b\\'\\'\\'c\\'\\'\\\\'", news);
+
+        // given
+        s = "\\'\\'\\'a'''b'''c\\'\\'\\'";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("\\'\\'\\'a\\'\\'\\'b\\'\\'\\'c\\'\\'\\'", news);
     }
 
     @Test

--- a/src/test/java/com/taosdata/jdbc/utils/UtilsTest.java
+++ b/src/test/java/com/taosdata/jdbc/utils/UtilsTest.java
@@ -1,6 +1,5 @@
 package com.taosdata.jdbc.utils;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.taosdata.jdbc.TSDBConstants;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,18 +20,60 @@ public class UtilsTest {
         Assert.assertEquals("\\'\\'\\'\\'\\'a\\'", news);
 
         // given
-        s = "'''''a\\'";
+        s = "abc";
         // when
         news = Utils.escapeSingleQuota(s);
         // then
-        Assert.assertEquals("\\'\\'\\'\\'\\'a\\'", news);
+        Assert.assertEquals("abc", news);
 
         // given
-        s = "'''''a\\'";
+        s = "\\a\\\\b\\\\c\\\\\\";
         // when
         news = Utils.escapeSingleQuota(s);
         // then
-        Assert.assertEquals("\\'\\'\\'\\'\\'a\\'", news);
+        Assert.assertEquals("\\a\\\\b\\\\c\\\\\\", news);
+
+        // given
+        s = "abc'";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("abc\\'", news);
+
+        // given
+        s = "a'bc";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("a\\'bc", news);
+
+        // given
+        s = "'abc";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("\\'abc", news);
+
+        // given
+        s = "'''a'''b'''c'''";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("\\'\\'\\'a\\'\\'\\'b\\'\\'\\'c\\'\\'\\'", news);
+
+        // given
+        s = "'''a\\'\\'\\'b'''c\\'\\'\\'";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("\\'\\'\\'a\\'\\'\\'b\\'\\'\\'c\\'\\'\\'", news);
+
+        // given
+        s = "'''a\\\\'\\'\\\\'b'''c\\'\\'\\\\'";
+        // when
+        news = Utils.escapeSingleQuota(s);
+        // then
+        Assert.assertEquals("\\'\\'\\'a\\\\'\\'\\\\'b\\'\\'\\'c\\'\\'\\\\'", news);
     }
 
     @Test


### PR DESCRIPTION
# Description

Using regex pattern to escape single quota has a big performance problem. I followed the previous unit tests, and then refactored Utils.escapeSingleQuota() method, and then added some more unit tests.

# Checklist

Please check the items in the checklist if applicable.

- [√] Is the user manual updated?
- [√] Are the test cases passed and automated?
- [√] Is there no significant decrease in test coverage?