### PR TITLE
fix: token for TMQ consumer auth without user name

### DIFF
--- a/src/main/java/com/taosdata/jdbc/ws/tmq/entity/ConsumerParam.java
+++ b/src/main/java/com/taosdata/jdbc/ws/tmq/entity/ConsumerParam.java
@@ -22,6 +22,7 @@ public class ConsumerParam {
         knownKeys.add(TSDBDriver.PROPERTY_KEY_PORT);
         knownKeys.add(TSDBDriver.PROPERTY_KEY_ENDPOINTS);
         knownKeys.add(TSDBDriver.PROPERTY_KEY_TOKEN);
+        knownKeys.add(TSDBDriver.PROPERTY_KEY_BEARER_TOKEN);
         knownKeys.add(TSDBDriver.PROPERTY_KEY_PRODUCT_NAME);
         knownKeys.add(TSDBDriver.PROPERTY_KEY_DBNAME);
         knownKeys.add(TSDBDriver.PROPERTY_KEY_USE_SSL);
@@ -102,6 +103,7 @@ public class ConsumerParam {
         String token = properties.getProperty(TMQConstants.TMQ_CONNECT_TOKEN);
         if (null != token && !token.isEmpty()) {
             config.put(TMQConstants.TMQ_CONNECT_TOKEN, token);
+            properties.setProperty(TSDBDriver.PROPERTY_KEY_BEARER_TOKEN, token);
         }
 
         if (null != properties.getProperty(TMQConstants.CONNECT_IP))

--- a/src/test/java/com/taosdata/jdbc/ws/WSConsumerEnterpriseTest.java
+++ b/src/test/java/com/taosdata/jdbc/ws/WSConsumerEnterpriseTest.java
@@ -43,85 +43,118 @@ public class WSConsumerEnterpriseTest {
     @Test
     @Description("test tmq consumer with td.connect.token parameter")
     public void testConsumerWithToken() throws Exception {
-        String token = "";
-        // create token
-        try (Connection conn = DriverManager.getConnection("jdbc:TAOS-WS://" + host + ":" + TestEnvUtil.getWsPort() + "/?user=" + TestEnvUtil.getUser() + "&password=" + TestEnvUtil.getPassword());
-                Statement stmt = conn.createStatement()) {
-            ResultSet rs = stmt.executeQuery("CREATE TOKEN jdbc_tmq_token FROM user " + TestEnvUtil.getUser() + " ENABLE 1 PROVIDER 'root' ttl 1");
+        String token = createToken("jdbc_tmq_token");
+
+        AtomicInteger counter = new AtomicInteger(1);
+        statement.executeUpdate("insert into ct0 values(now, " + counter.getAndIncrement() + ")");
+        ScheduledExecutorService dataProducer = startDataProducer(statement, counter);
+
+        statement.executeUpdate("create topic if not exists " + topicName + " as select ts, c1 from ct0");
+
+        Properties properties = createConsumerProperties(token);
+        try (TaosConsumer<Map<String, Object>> consumer = new TaosConsumer<>(properties)) {
+            consumer.subscribe(Collections.singletonList(topicName));
+            pollAndValidateRecords(consumer);
+            consumer.unsubscribe();
+        } finally {
+            dataProducer.shutdown();
+            dropToken("jdbc_tmq_token");
+        }
+    }
+
+    @Test
+    @Description("test tmq consumer with td.connect.token parameter with user/password")
+    public void testConsumerWithTokenAndUser() throws Exception {
+        String token = createToken("jdbc_tmq_token");
+
+        AtomicInteger counter = new AtomicInteger(1);
+        statement.executeUpdate("insert into ct0 values(now, " + counter.getAndIncrement() + ")");
+        ScheduledExecutorService dataProducer = startDataProducer(statement, counter);
+
+        statement.executeUpdate("create topic if not exists " + topicName + " as select ts, c1 from ct0");
+
+        Properties properties = createConsumerProperties(token);
+        properties.setProperty(TMQConstants.CONNECT_USER, TestEnvUtil.getUser() + "t");
+        properties.setProperty(TMQConstants.CONNECT_PASS, TestEnvUtil.getPassword());
+        try (TaosConsumer<Map<String, Object>> consumer = new TaosConsumer<>(properties)) {
+            consumer.subscribe(Collections.singletonList(topicName));
+            pollAndValidateRecords(consumer);
+            consumer.unsubscribe();
+        } finally {
+            dataProducer.shutdown();
+            dropToken("jdbc_tmq_token");
+        }
+    }
+
+    private String createToken(String tokenName) throws Exception {
+        try (Connection conn = getTestConnection();
+             Statement stmt = conn.createStatement()) {
+            ResultSet rs = stmt.executeQuery("CREATE TOKEN " + tokenName + " FROM user " + TestEnvUtil.getUser() + " ENABLE 1 PROVIDER 'root' ttl 1");
             TestUtils.waitTransactionDone(conn);
             rs.next();
-            token = rs.getString(1);
+            String token = rs.getString(1);
             System.out.println("created token = " + token);
-            rs.close();
+            return token;
         }
+    }
 
-        if (token == null || token.isEmpty()) {
-            Assert.fail("no token created");
+    private void dropToken(String tokenName) throws Exception {
+        try (Connection conn = getTestConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("drop token " + tokenName);
+            TestUtils.waitTransactionDone(conn);
+            System.out.println("token dropped");
         }
+    }
 
-        AtomicInteger a = new AtomicInteger(1);
-        statement.executeUpdate("insert into ct0 values(now, " + a.getAndIncrement() + ")");
-
-        ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r -> {
+    private ScheduledExecutorService startDataProducer(Statement stmt, AtomicInteger counter) throws SQLException {
+        stmt.executeUpdate("insert into ct0 values(now, " + counter.getAndIncrement() + ")");
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r);
             t.setName("topic-thread-" + t.getId());
             return t;
         });
-        scheduledExecutorService.scheduleWithFixedDelay(() -> {
+        executor.scheduleWithFixedDelay(() -> {
             try {
-                statement.executeUpdate("insert into ct0 values(now, " + a.getAndIncrement() + ")");
+                stmt.executeUpdate("insert into ct0 values(now, " + counter.getAndIncrement() + ")");
             } catch (SQLException e) {
                 e.printStackTrace();
             }
         }, 0, 10, TimeUnit.MILLISECONDS);
+        return executor;
+    }
 
-        // create topic
-        statement.executeUpdate("create topic if not exists " + topicName + " as select ts, c1 from ct0");
-
-        // create consumer with td.connect.token
+    private Properties createConsumerProperties(String token) {
         Properties properties = new Properties();
-        properties.setProperty(TMQConstants.TMQ_CONNECT_TOKEN, token);  // use td.connect.token
-        properties.setProperty(TMQConstants.CONNECT_USER, TestEnvUtil.getUser());  // still set user/password (server will handle priority)
-        properties.setProperty(TMQConstants.CONNECT_PASS, TestEnvUtil.getPassword());
+        properties.setProperty(TMQConstants.TMQ_CONNECT_TOKEN, token);
         properties.setProperty(TMQConstants.BOOTSTRAP_SERVERS, host + ":" + TestEnvUtil.getWsPort());
         properties.setProperty(TMQConstants.MSG_WITH_TABLE_NAME, "true");
         properties.setProperty(TMQConstants.ENABLE_AUTO_COMMIT, "true");
         properties.setProperty(TMQConstants.GROUP_ID, "ws_token_group");
         properties.setProperty(TMQConstants.CONNECT_TYPE, "ws");
+        return properties;
+    }
 
-        try (TaosConsumer<Map<String, Object>> consumer = new TaosConsumer<>(properties)) {
-            consumer.subscribe(Collections.singletonList(topicName));
-
-            // poll some data
-            int totalRecords = 0;
-            for (int i = 0; i < 10; i++) {
-                ConsumerRecords<Map<String, Object>> consumerRecords = consumer.poll(Duration.ofMillis(100));
-                for (ConsumerRecord<Map<String, Object>> r : consumerRecords) {
-                    Map<String, Object> map = r.value();
-                    Assert.assertEquals(2, map.size());  // ts and c1
-                    Assert.assertTrue(map.get("ts") instanceof Timestamp);
-                    totalRecords++;
-                }
-                if (totalRecords > 0) {
-                    break;
-                }
+    private void pollAndValidateRecords(TaosConsumer<Map<String, Object>> consumer) throws Exception {
+        int totalRecords = 0;
+        for (int i = 0; i < 10; i++) {
+            ConsumerRecords<Map<String, Object>> consumerRecords = consumer.poll(Duration.ofMillis(100));
+            for (ConsumerRecord<Map<String, Object>> r : consumerRecords) {
+                Map<String, Object> map = r.value();
+                Assert.assertEquals(2, map.size());
+                Assert.assertTrue(map.get("ts") instanceof Timestamp);
+                totalRecords++;
             }
-
-            Assert.assertTrue("Should have received at least some records", totalRecords > 0);
-            System.out.println("Successfully consumed " + totalRecords + " records using token authentication");
-
-            consumer.unsubscribe();
-        } finally {
-            scheduledExecutorService.shutdown();
-
-            // revoke token
-            try (Connection conn = DriverManager.getConnection("jdbc:TAOS-WS://" + host + ":" + TestEnvUtil.getWsPort() + "/?user=" + TestEnvUtil.getUser() + "&password=" + TestEnvUtil.getPassword());
-                    Statement stmt = conn.createStatement()) {
-                stmt.executeUpdate("drop token jdbc_tmq_token");
-                TestUtils.waitTransactionDone(conn);
-                System.out.println("token dropped");
+            if (totalRecords > 0) {
+                break;
             }
         }
+        Assert.assertTrue("Should have received at least some records", totalRecords > 0);
+        System.out.println("Successfully consumed " + totalRecords + " records using token authentication");
+    }
+
+    private Connection getTestConnection() throws Exception {
+        return DriverManager.getConnection("jdbc:TAOS-WS://" + host + ":" + TestEnvUtil.getWsPort() + "/?user=" + TestEnvUtil.getUser() + "&password=" + TestEnvUtil.getPassword());
     }
 
     @BeforeClass


### PR DESCRIPTION

# Description

Add bearer token property to ConsumerParam known keys and sync td.connect.token into bearer token config for WS auth usage.

Refactor WSConsumerEnterpriseTest token helpers and add coverage for token auth when user/password are incorrect.


# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
