### PR TITLE
fix: initialize catalog from connection properties

### DIFF
--- a/deploy-pom.xml
+++ b/deploy-pom.xml
@@ -45,7 +45,7 @@
         <jackson.version>2.21.1</jackson.version>
         <httpclient.version>4.5.14</httpclient.version>
         <guava.version>33.5.0-jre</guava.version>
-        <netty-all.version>4.2.11.Final</netty-all.version>
+        <netty-all.version>4.2.13.Final</netty-all.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <byte-buddy.version>1.12.22</byte-buddy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jackson.version>2.21.1</jackson.version>
         <httpclient.version>4.5.14</httpclient.version>
         <guava.version>33.5.0-jre</guava.version>
-        <netty-all.version>4.2.11.Final</netty-all.version>
+        <netty-all.version>4.2.13.Final</netty-all.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>4.11.0</mockito.version>
         <byte-buddy.version>1.12.22</byte-buddy.version>

--- a/src/main/java/com/taosdata/jdbc/AbstractConnection.java
+++ b/src/main/java/com/taosdata/jdbc/AbstractConnection.java
@@ -28,6 +28,7 @@ public abstract class AbstractConnection extends WrapperImpl implements Connecti
         for (String propName : propNames) {
             clientInfoProps.setProperty(propName, properties.getProperty(propName));
         }
+        this.catalog = properties.getProperty(TSDBDriver.PROPERTY_KEY_DBNAME);
         serverVersion = version;
         supportBlob = VersionUtil.surpportBlob(serverVersion);
         supportLineBind = supportBlob;

--- a/src/test/java/com/taosdata/jdbc/AbstractConnectionTest.java
+++ b/src/test/java/com/taosdata/jdbc/AbstractConnectionTest.java
@@ -16,7 +16,11 @@ public class AbstractConnectionTest {
 
     @Before
     public void setUp() {
-        connection = new AbstractConnection(new Properties(), TSDBConstants.UNKNOWN_VERSION) {
+        connection = newConnection(new Properties());
+    }
+
+    private AbstractConnection newConnection(Properties properties) {
+        return new AbstractConnection(properties, TSDBConstants.UNKNOWN_VERSION) {
             @Override
             public Statement createStatement() throws SQLException {
                 return null; // Mock implementation
@@ -235,6 +239,20 @@ public class AbstractConnectionTest {
     public void testGetCatalog() throws SQLException {
         connection.setCatalog("testCatalog");
         assertEquals("testCatalog", connection.getCatalog());
+    }
+
+    @Test
+    public void testGetCatalogFromProperties() throws SQLException {
+        Properties properties = new Properties();
+        properties.setProperty(TSDBDriver.PROPERTY_KEY_DBNAME, "test_catalog");
+        connection = newConnection(properties);
+        assertEquals("test_catalog", connection.getCatalog());
+    }
+
+    @Test
+    public void testGetCatalogWithoutPropertiesDatabase() throws SQLException {
+        connection = newConnection(new Properties());
+        assertNull(connection.getCatalog());
     }
 
     @Test(expected = SQLException.class)

--- a/src/test/java/com/taosdata/jdbc/ws/WSConnectionTest.java
+++ b/src/test/java/com/taosdata/jdbc/ws/WSConnectionTest.java
@@ -30,13 +30,13 @@ public class WSConnectionTest {
     private final String dbName = "information_schema";
 
     @Test
-    @Ignore
     @Description("normal test with websocket server")
     public void normalConnection() throws SQLException {
         String url = "jdbc:TAOS-RS://" + host + ":" + port + "/" + dbName + "?user=" + TestEnvUtil.getUser() + "&password=" + TestEnvUtil.getPassword();
         Properties properties = new Properties();
         properties.setProperty(TSDBDriver.PROPERTY_KEY_BATCH_LOAD, "true");
         connection = DriverManager.getConnection(url, properties);
+        Assert.assertEquals(dbName, connection.getCatalog());
     }
 
     @Test
@@ -46,6 +46,7 @@ public class WSConnectionTest {
         Properties properties = new Properties();
         properties.setProperty(TSDBDriver.PROPERTY_KEY_BATCH_LOAD, "true");
         connection = DriverManager.getConnection(url, properties);
+        Assert.assertNull(connection.getCatalog());
     }
 
     @Test


### PR DESCRIPTION
# Description

initialize catalog from connection properties

# Issue(s)

- Close: [Issue Link](https://project.feishu.cn/taosdata_td/defect/detail/6980196872)

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
