### PR TITLE
fix(ws): schemaless 多行写入合并为单帧 (#35361)

### DIFF
--- a/src/main/java/com/taosdata/jdbc/SchemalessWriter.java
+++ b/src/main/java/com/taosdata/jdbc/SchemalessWriter.java
@@ -225,21 +225,7 @@ public class SchemalessWriter implements AutoCloseable {
                 break;
             }
             case WS: {
-                for (String line : lines) {
-                    InsertReq insertReq = new InsertReq();
-                    insertReq.setReqId(insertId.getAndIncrement());
-                    insertReq.setProtocol(protocolType.ordinal());
-                    insertReq.setPrecision(timestampType.getType());
-                    insertReq.setData(line);
-                    if (ttl != null)
-                        insertReq.setTtl(ttl);
-                    if (reqId != null)
-                        insertReq.setReqId(reqId);
-                    CommonResp response = (CommonResp) transport.send(new Request(SchemalessAction.INSERT.getAction(), insertReq));
-                    if (Code.SUCCESS.getCode() != response.getCode()) {
-                        throw new SQLException("(0x" + Integer.toHexString(response.getCode()) + "):" + response.getMessage());
-                    }
-                }
+                wsBatchInsert(lines, protocolType, timestampType, ttl, reqId);
                 break;
             }
             default:
@@ -262,25 +248,45 @@ public class SchemalessWriter implements AutoCloseable {
                 break;
             }
             case WS: {
-                for (String line : lines) {
-                    InsertReq insertReq = new InsertReq();
-                    insertReq.setReqId(insertId.getAndIncrement());
-                    insertReq.setProtocol(protocolType.ordinal());
-                    insertReq.setPrecision(timestampType.getType());
-                    insertReq.setData(line);
-                    if (ttl != null)
-                        insertReq.setTtl(ttl);
-                    if (reqId != null)
-                        insertReq.setReqId(reqId);
-                    CommonResp response = (CommonResp) transport.send(new Request(SchemalessAction.INSERT.getAction(), insertReq));
-                    if (Code.SUCCESS.getCode() != response.getCode()) {
-                        throw new SQLException("0x" + Integer.toHexString(response.getCode()) + ":" + response.getMessage());
-                    }
-                }
+                wsBatchInsert(lines, protocolType, timestampType, ttl, reqId);
                 break;
             }
             default:
                 // nothing
+        }
+    }
+
+    // Coalesces a batch into a single WS schemaless INSERT frame when the protocol allows it
+    // (LINE/TELNET are newline-separated; JSON elements are independent documents and must
+    // stay one-per-frame). This removes the N synchronous round-trips that made WS schemaless
+    // an order of magnitude slower than native (issue #35361).
+    private void wsBatchInsert(String[] lines, SchemalessProtocolType protocolType, SchemalessTimestampType timestampType, Integer ttl, Long reqId) throws SQLException {
+        if (lines == null || lines.length == 0) {
+            return;
+        }
+        if (protocolType == SchemalessProtocolType.JSON && lines.length > 1) {
+            for (String line : lines) {
+                wsSendInsert(line, protocolType, timestampType, ttl, reqId);
+            }
+            return;
+        }
+        String payload = lines.length == 1 ? lines[0] : String.join("\n", lines);
+        wsSendInsert(payload, protocolType, timestampType, ttl, reqId);
+    }
+
+    private void wsSendInsert(String data, SchemalessProtocolType protocolType, SchemalessTimestampType timestampType, Integer ttl, Long reqId) throws SQLException {
+        InsertReq insertReq = new InsertReq();
+        insertReq.setReqId(insertId.getAndIncrement());
+        insertReq.setProtocol(protocolType.ordinal());
+        insertReq.setPrecision(timestampType.getType());
+        insertReq.setData(data);
+        if (ttl != null)
+            insertReq.setTtl(ttl);
+        if (reqId != null)
+            insertReq.setReqId(reqId);
+        CommonResp response = (CommonResp) transport.send(new Request(SchemalessAction.INSERT.getAction(), insertReq));
+        if (Code.SUCCESS.getCode() != response.getCode()) {
+            throw new SQLException("(0x" + Integer.toHexString(response.getCode()) + "):" + response.getMessage());
         }
     }
 

--- a/src/main/java/com/taosdata/jdbc/SchemalessWriter.java
+++ b/src/main/java/com/taosdata/jdbc/SchemalessWriter.java
@@ -264,6 +264,13 @@ public class SchemalessWriter implements AutoCloseable {
         if (lines == null || lines.length == 0) {
             return;
         }
+        // Reject null elements up-front: String.join("\n", lines) would otherwise inline the
+        // literal "null" into the coalesced payload and the server would fail to parse it.
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i] == null) {
+                throw new SQLException("schemaless line at index " + i + " must not be null");
+            }
+        }
         if (protocolType == SchemalessProtocolType.JSON && lines.length > 1) {
             for (String line : lines) {
                 wsSendInsert(line, protocolType, timestampType, ttl, reqId);

--- a/src/main/java/com/taosdata/jdbc/ws/WSConnection.java
+++ b/src/main/java/com/taosdata/jdbc/ws/WSConnection.java
@@ -164,6 +164,13 @@ public class WSConnection extends AbstractConnection {
         if (lines == null || lines.length == 0) {
             return;
         }
+        // Reject null elements up-front: String.join("\n", lines) would otherwise inline the
+        // literal "null" into the coalesced payload and the server would fail to parse it.
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i] == null) {
+                throw new SQLException("schemaless line at index " + i + " must not be null");
+            }
+        }
         // JSON: each element is an independent document; cannot be merged with '\n'.
         // LINE/TELNET: server accepts newline-separated batches, so coalesce into a single
         // WS frame to avoid one synchronous round-trip per line (issue #35361).

--- a/src/main/java/com/taosdata/jdbc/ws/WSConnection.java
+++ b/src/main/java/com/taosdata/jdbc/ws/WSConnection.java
@@ -161,20 +161,35 @@ public class WSConnection extends AbstractConnection {
 
     @Override
     public void write(String[] lines, SchemalessProtocolType protocolType, SchemalessTimestampType timestampType, Integer ttl, Long reqId) throws SQLException {
-        for (String line : lines) {
-            InsertReq insertReq = new InsertReq();
-            insertReq.setReqId(insertId.getAndIncrement());
-            insertReq.setProtocol(protocolType.ordinal());
-            insertReq.setPrecision(timestampType.getType());
-            insertReq.setData(line);
-            if (ttl != null)
-                insertReq.setTtl(ttl);
-            if (reqId != null)
-                insertReq.setReqId(reqId);
-            CommonResp response = (CommonResp) transport.send(new Request(SchemalessAction.INSERT.getAction(), insertReq), param.getRequestTimeout());
-            if (Code.SUCCESS.getCode() != response.getCode()) {
-                throw new SQLException("0x" + Integer.toHexString(response.getCode()) + ":" + response.getMessage());
+        if (lines == null || lines.length == 0) {
+            return;
+        }
+        // JSON: each element is an independent document; cannot be merged with '\n'.
+        // LINE/TELNET: server accepts newline-separated batches, so coalesce into a single
+        // WS frame to avoid one synchronous round-trip per line (issue #35361).
+        if (protocolType == SchemalessProtocolType.JSON && lines.length > 1) {
+            for (String line : lines) {
+                sendInsert(line, protocolType, timestampType, ttl, reqId);
             }
+            return;
+        }
+        String payload = lines.length == 1 ? lines[0] : String.join("\n", lines);
+        sendInsert(payload, protocolType, timestampType, ttl, reqId);
+    }
+
+    private void sendInsert(String data, SchemalessProtocolType protocolType, SchemalessTimestampType timestampType, Integer ttl, Long reqId) throws SQLException {
+        InsertReq insertReq = new InsertReq();
+        insertReq.setReqId(insertId.getAndIncrement());
+        insertReq.setProtocol(protocolType.ordinal());
+        insertReq.setPrecision(timestampType.getType());
+        insertReq.setData(data);
+        if (ttl != null)
+            insertReq.setTtl(ttl);
+        if (reqId != null)
+            insertReq.setReqId(reqId);
+        CommonResp response = (CommonResp) transport.send(new Request(SchemalessAction.INSERT.getAction(), insertReq), param.getRequestTimeout());
+        if (Code.SUCCESS.getCode() != response.getCode()) {
+            throw new SQLException("0x" + Integer.toHexString(response.getCode()) + ":" + response.getMessage());
         }
     }
 

--- a/src/test/java/com/taosdata/jdbc/ws/WSSchemalessNewTest.java
+++ b/src/test/java/com/taosdata/jdbc/ws/WSSchemalessNewTest.java
@@ -269,6 +269,37 @@ public class WSSchemalessNewTest {
         statement.close();
     }
 
+    // Regression guard for issue #35361: a multi-line LINE batch must be coalesced into a
+    // single WS frame on the client. If the WS path ever reverts to one frame per line,
+    // either the row count breaks or the wall-clock balloons by orders of magnitude.
+    @Test
+    public void testLargeLineBatchCoalesced() throws SQLException {
+        int n = 1000;
+        String[] lines = new String[n];
+        long baseTs = 1700000000000L;
+        for (int i = 0; i < n; i++) {
+            lines[i] = "stb_batch,host=h" + (i % 16)
+                    + " v=" + (i * 1.5) + "f64,k=" + i + "i64"
+                    + " " + (baseTs + i);
+        }
+
+        long t0 = System.nanoTime();
+        ((AbstractConnection) connection).write(lines, SchemalessProtocolType.LINE, SchemalessTimestampType.MILLI_SECONDS);
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        try (Statement s = connection.createStatement()) {
+            s.executeUpdate("use " + DB_NAME);
+            try (ResultSet rs = s.executeQuery("select count(*) from stb_batch")) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(n, rs.getLong(1));
+            }
+        }
+        // The pre-fix per-line loop did >1000 round-trips; that was multi-second even on
+        // localhost. 5s is a generous ceiling that still catches a regression.
+        Assert.assertTrue("batch took " + elapsedMs + " ms; suspect per-line round-trip regression",
+                elapsedMs < 5000);
+    }
+
     @Test
     public void telnetListInsert() throws SQLException {
         // given

--- a/src/test/java/com/taosdata/jdbc/ws/WSSchemalessNewTest.java
+++ b/src/test/java/com/taosdata/jdbc/ws/WSSchemalessNewTest.java
@@ -300,6 +300,25 @@ public class WSSchemalessNewTest {
                 elapsedMs < 5000);
     }
 
+    // Defensive: a null element in the batch must be rejected up-front. Without this guard
+    // String.join("\n", lines) would inline the literal "null" into the coalesced payload
+    // and the server would fail to parse it (potentially polluting the rest of the batch).
+    @Test
+    public void testRejectsNullLineInBatch() {
+        String[] lines = new String[]{
+                "stb_null_check,host=h1 v=1i64 1700000001000",
+                null,
+                "stb_null_check,host=h2 v=2i64 1700000002000"
+        };
+        try {
+            ((AbstractConnection) connection).write(lines, SchemalessProtocolType.LINE, SchemalessTimestampType.MILLI_SECONDS);
+            Assert.fail("expected SQLException for null element at index 1");
+        } catch (SQLException e) {
+            Assert.assertTrue("error message should mention the offending index, got: " + e.getMessage(),
+                    e.getMessage() != null && e.getMessage().contains("index 1"));
+        }
+    }
+
     @Test
     public void telnetListInsert() throws SQLException {
         // given


### PR DESCRIPTION
issue [#35361](https://github.com/taosdata/TDengine/issues/35361)：WS schemaless 写入比原生慢约一个数量级。

**原因**：`WSConnection.write(String[], ...)` 和 `SchemalessWriter.write(String[], ...)` 对每一行单独发一个 WS frame 并在 `Transport.send()` 同步等响应，N 行 = N 次串行 RTT。原生 JNI 一次 C 调 `taos_schemaless_insert` 把整批传完，所以没这个问题。

**改动**：LINE / TELNET 用 `String.join("\n", lines)` 拼成单个 payload，单次发送一帧；JSON 保留每元素一帧（独立文档不能合并）；null 元素 fail-fast 抛 `SQLException`。只动 WS 分支，JNI 和 `writeRaw` 未动。服务端无需变动 —— `writeRaw(String, ...)` 一直就是这个格式。

**基准**（8973 行 × 20 iter，TDengine 3.3.6.13，container loopback）：

|  | p50 | mean |
|---|---|---|
| WS 修复前 | 19,043 ms | 19,099 ms |
| **WS 修复后** | **184 ms** | **194 ms** |
| native JNI（对照） | 49 ms | 61 ms |

约 **98×** 提速；三种 mode 都写入 206,379 行，无丢数。

**测试**：新增 `WSSchemalessNewTest.testLargeLineBatchCoalesced`（1000 行 + 5s 上限）和 `testRejectsNullLineInBatch`；现有 `testLine` / `testLine2` / `telnetInsert` / `telnetListInsert` 自动覆盖。7/7 通过。

Refs taosdata/TDengine#35361